### PR TITLE
Fire change event from new row

### DIFF
--- a/packages/Core/src/query.ts
+++ b/packages/Core/src/query.ts
@@ -1145,7 +1145,7 @@ export class _nanoSQLQuery implements InanoSQLQueryExec {
                         const changeEvent: InanoSQLDatabaseEvent = {
                             target: this.query.table as string,
                             path: "*",
-                            events: ["upsert", "*"],
+                            events: ["upsert", "change", "*"],
                             time: Date.now(),
                             performance: Date.now() - this._startTime,
                             result: rowToAdd.res,


### PR DESCRIPTION
According to docs (https://nanosql.gitbook.io/docs/query/events), change should be fired with new rows (which makes sense, since observers also rely on change event). 
